### PR TITLE
Settings: Add some more entries into 'SMS message limit' menu

### DIFF
--- a/res/values/cm_arrays.xml
+++ b/res/values/cm_arrays.xml
@@ -123,6 +123,9 @@
 
     <!-- Sms security limit -->
     <string-array name="sms_security_check_limit_entries" translatable="false">
+        <item>@string/sms_security_check_limit_none</item>
+        <item>5</item>
+        <item>10</item>
         <item>30</item>
         <item>50</item>
         <item>100</item>
@@ -130,6 +133,9 @@
     </string-array>
 
     <string-array name="sms_security_check_limit_values" translatable="false">
+        <item>0</item>
+        <item>5</item>
+        <item>10</item>
         <item>30</item>
         <item>50</item>
         <item>100</item>

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -267,10 +267,12 @@
     <string name="display_rotation_180_title">180 degrees</string>
     <string name="display_rotation_270_title">270 degrees</string>
 
-    <!--- Sms security limit -->
+    <!-- Sms security limit -->
     <string name="app_security_title">App security</string>
     <string name="sms_security_check_limit_title">SMS message limit</string>
     <string name="sms_security_check_limit_summary">Apps can send %d messages in 30 minutes before requiring confirmation</string>
+    <string name="sms_security_check_limit_summary_none">Apps are not allowed to send any messages without confirmation</string>
+    <string name="sms_security_check_limit_none">None</string>
 
     <string name="spam_added_title">Added %1$s</string>
     <string name="spam_last_blocked_title">Last blocked %1$s</string>

--- a/src/com/android/settings/SecuritySettings.java
+++ b/src/com/android/settings/SecuritySettings.java
@@ -480,8 +480,10 @@ public class SecuritySettings extends SettingsPreferenceFragment
         }
     }
 
-    private void updateSmsSecuritySummary(int i) {
-        String message = getString(R.string.sms_security_check_limit_summary, i);
+    private void updateSmsSecuritySummary(int selection) {
+        String message = selection > 0
+                ? getString(R.string.sms_security_check_limit_summary, selection)
+                : getString(R.string.sms_security_check_limit_summary_none);
         mSmsSecurityCheck.setSummary(message);
     }
 
@@ -534,7 +536,7 @@ public class SecuritySettings extends SettingsPreferenceFragment
             }
         } else if (KEY_SMS_SECURITY_CHECK_PREF.equals(key)) {
             int smsSecurityCheck = Integer.valueOf((String) value);
-            Settings.Secure.putInt(getContentResolver(), Settings.Global.SMS_OUTGOING_CHECK_MAX_COUNT,
+            Settings.Global.putInt(getContentResolver(), Settings.Global.SMS_OUTGOING_CHECK_MAX_COUNT,
                     smsSecurityCheck);
             updateSmsSecuritySummary(smsSecurityCheck);
         } else if (LOCK_TO_CYANOGEN_ACCOUNT.equals(key)) {


### PR DESCRIPTION
* Add None, 5 and 10 entries into 'SMS message limit' menu.
* Properly write limit value to Settings.Global

Change-Id: I8b206ae6c9f73378da65b09e68898de31439cc59